### PR TITLE
Refactor

### DIFF
--- a/src/main/app/esb_mule.xml
+++ b/src/main/app/esb_mule.xml
@@ -57,12 +57,15 @@ http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/
         <http:listener config-ref="HTTP_Listener_Configuration" path="/" doc:name="HTTP"/>
         <cxf:proxy-service configuration-ref="CXF_Configuration" payload="envelope" doc:name="CXF"/>
         <mulexml:dom-to-xml-transformer doc:name="DOM to XML"/>
-        <logger message="Original Payload is #[message.payload]" level="WARN" doc:name="Payload Input"/>
         <flow-ref name="get_input_params_sf" doc:name="get_input_params_sf"/>
-        <flow-ref name="communicate_with_pdp_sf" doc:name="communicate_with_pdp_sf"/>
-        <flow-ref name="read_response_pdp_sf" doc:name="read_response_pdp_sf"/>
-        <flow-ref name="apply_obligations_sf" doc:name="apply_obligations_sf"/>
+        <flow-ref name="prepare_to_rfa_sf" doc:name="prepare_to_rfa_sf"/>
+        <flow-ref name="fetch_read_apply_sf" doc:name="fetch_read_apply_sf"/>
         <flow-ref name="communicate_with_organization_sf" doc:name="communicate_with_organization_sf"/>
+        <response>
+            <logger level="INFO" doc:name="Prepare output to initial endpoint"/>
+            <logger level="INFO" doc:name="Call fetch_read_apply_sf"/>
+            <flow-ref name="prepare_to_rfa_sf" doc:name="prepare_to_rfa_sf"/>
+        </response>
         <logger message="FINISH!!!!!" level="INFO" doc:name="FINISH"/>
     </flow>
 </mule>

--- a/src/main/app/fetch_read_apply.xml
+++ b/src/main/app/fetch_read_apply.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+    <sub-flow name="fetch_read_apply_sf">
+        <flow-ref name="communicate_with_pdp_sf" doc:name="communicate_with_pdp_sf"/>
+        <flow-ref name="read_response_pdp_sf" doc:name="read_response_pdp_sf"/>
+        <flow-ref name="apply_obligations_sf" doc:name="apply_obligations_sf"/>
+    </sub-flow>
+</mule>

--- a/src/main/app/mule-deploy.properties
+++ b/src/main/app/mule-deploy.properties
@@ -1,6 +1,6 @@
 #** GENERATED CONTENT ** Mule Application Deployment Descriptor
-#Fri Mar 31 20:55:45 UYT 2017
+#Mon Apr 10 23:45:05 UYT 2017
 redeployment.enabled=true
 encoding=UTF-8
-config.resources=apply_obligations.xml,communicate_with_organization.xml,communicate_with_pdp.xml,esb_mule.xml,get_input_params.xml,read_response_pdp.xml
 domain=default
+config.resources=apply_obligations.xml,communicate_with_organization.xml,communicate_with_pdp.xml,esb_mule.xml,fetch_read_apply.xml,get_input_params.xml,prepare_to_rfa.xml,read_response_pdp.xml

--- a/src/main/app/prepare_to_rfa.xml
+++ b/src/main/app/prepare_to_rfa.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+    <sub-flow name="prepare_to_rfa_sf">
+        <logger message="Here goes the transformation to get the Source in a Json Format" level="INFO" doc:name="Logger"/>
+    </sub-flow>
+</mule>

--- a/src/main/resources/globalFunctions.mvel
+++ b/src/main/resources/globalFunctions.mvel
@@ -1,0 +1,3 @@
+def convertToString(data){
+	return data.toString();
+}


### PR DESCRIPTION
This PR contains:

* Refactor regarding double request to PDP

<img width="1215" alt="screen shot 2017-04-11 at 00 21 39" src="https://cloud.githubusercontent.com/assets/12576190/24891553/f1920adc-1e4c-11e7-98ee-37c35216b8d5.png">

TODO:
* _globalFunctions.mvel_ will be the apply obligations module. The anypoint code must migrate to that file.
* _prepare_to_rfa_ module is responsible for transforming the data to be the input of _fetch_read_apply_ module
* adjust _communicate_with_organization_ module, the response from the service must be to apply the _prepare_to_rfa_ module

