### PR TITLE
Prevent input and data service wrong format

### DIFF
--- a/src/main/app/control_input_structure.xml
+++ b/src/main/app/control_input_structure.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+    <sub-flow name="control_input_structure_sf">
+        <dw:transform-message doc:name="Transform Message">
+            <dw:set-variable variableName="control_input_structure"><![CDATA[%dw 1.0
+%input payload application/xml
+%output application/java
+%namespace soapenv http://schemas.xmlsoap.org/soap/envelope/
+%var persona=payload.soapenv#Envelope.soapenv#Body.Persona
+%var tipoDocumento=persona.tipo_documento
+%var numeroDocumento=persona.numero_documento
+---
+{
+	tipo_documento: tipoDocumento,
+	numero_documento: numeroDocumento
+}]]></dw:set-variable>
+        </dw:transform-message>
+    </sub-flow>
+</mule>

--- a/src/main/app/control_service_structure.xml
+++ b/src/main/app/control_service_structure.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+    <sub-flow name="control_service_structure_sf">
+        <dw:transform-message doc:name="Transform Message">
+            <dw:set-variable variableName="control_service_structure"><![CDATA[%dw 1.0
+%input payload application/xml
+%output application/java
+%var data=payload.data
+---
+{
+	data: data
+}]]></dw:set-variable>
+        </dw:transform-message>
+    </sub-flow>
+</mule>

--- a/src/main/app/esb_mule.xml
+++ b/src/main/app/esb_mule.xml
@@ -59,6 +59,27 @@ http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/jso
         <http:listener config-ref="HTTP_Listener_Configuration" path="/" doc:name="HTTP"/>
         <cxf:proxy-service configuration-ref="CXF_Configuration" payload="envelope" doc:name="CXF"/>
         <mulexml:dom-to-xml-transformer doc:name="DOM to XML"/>
+        <flow-ref name="control_input_structure_sf" doc:name="control_input_structure_sf"/>
+        <choice doc:name="Choice">
+            <when expression="#[flowVars.control_input_structure.tipo_documento != null &amp;&amp; flowVars.control_input_structure.numero_documento != null]">
+                <flow-ref name="correct_input_params_f" doc:name="correct_input_params_f"/>
+            </when>
+            <otherwise>
+                <dw:transform-message doc:name="Wrong Input Params">
+                    <dw:set-payload><![CDATA[%dw 1.0
+%output application/xml
+---
+{
+	response: {
+		info: "Wrong input params"
+	}
+}]]></dw:set-payload>
+                </dw:transform-message>
+            </otherwise>
+        </choice>
+        <logger message="FINISH!!!!!" level="INFO" doc:name="FINISH"/>
+    </flow>
+    <sub-flow name="correct_input_params_f">
         <flow-ref name="get_input_params_sf" doc:name="get_input_params_sf"/>
         <flow-ref name="fetch_read_apply_sf" doc:name="fetch_read_apply_sf"/>
         <choice doc:name="Check PDP decision">
@@ -75,7 +96,7 @@ http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/jso
                 </dw:transform-message>
             </when>
             <when expression="#[message.inboundProperties['http.status'] == 200]">
-                <flow-ref name="not_deny_flow" doc:name="not_deny_flow"/>
+                <flow-ref name="not_deny_f" doc:name="not_deny_f"/>
             </when>
             <otherwise>
                 <dw:transform-message doc:name="Transform Message">
@@ -88,12 +109,31 @@ http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/jso
                 </dw:transform-message>
             </otherwise>
         </choice>
-        <logger message="FINISH!!!!!" level="INFO" doc:name="FINISH"/>
-    </flow>
-    <sub-flow name="not_deny_flow">
+    </sub-flow>
+    <sub-flow name="not_deny_f">
         <flow-ref name="communicate_with_organization_sf" doc:name="communicate_with_organization_sf"/>
         <json:json-to-xml-transformer doc:name="JSON to XML"/>
-        <set-variable variableName="servicePayload" value="#[message.payload]" encoding="UTF-8" mimeType="application/xml" doc:name="Save Payload"/>
+        <flow-ref name="control_service_structure_sf" doc:name="control_service_structure_sf"/>
+        <choice doc:name="Choice">
+            <when expression="#[flowVars.control_service_structure.data != null]">
+                <flow-ref name="correct_service_structure_f" doc:name="correct_service_structure_f"/>
+            </when>
+            <otherwise>
+                <dw:transform-message doc:name="Transform Message">
+                    <dw:set-payload><![CDATA[%dw 1.0
+%output application/xml
+---
+{
+	response: {
+		info: "Wrong structure data service"
+	}
+}]]></dw:set-payload>
+                </dw:transform-message>
+            </otherwise>
+        </choice>
+    </sub-flow>
+    <sub-flow name="correct_service_structure_f">
+        <set-variable variableName="servicePayload" value="#[payload]" encoding="UTF-8" mimeType="application/xml" doc:name="Save Payload"/>
         <logger message="Vuelta desde la organizacion" level="INFO" doc:name="Logger"/>
         <choice doc:name="Check response status">
             <when expression="#[message.outboundProperties['http.status'] != 200]">
@@ -102,7 +142,7 @@ http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/jso
             <otherwise>
                 <flow-ref name="prepare_to_rf_sf" doc:name="prepare_to_rf_sf"/>
                 <flow-ref name="fetch_read_apply_sf" doc:name="fetch_read_apply_sf"/>
-                <set-payload value="#[flowVars.originalPayload]" doc:name="Set Payload" encoding="UTF-8" mimeType="application/xml"/>
+                <set-payload value="#[flowVars.originalPayload]" encoding="UTF-8" mimeType="application/xml" doc:name="Set Payload"/>
                 <flow-ref name="communicate_with_cep_f" doc:name="communicate_with_cep_f"/>
                 <choice doc:name="Check PDP decision">
                     <when expression="#[flowVars.applyObligations.Result.Decision == 'Deny']">


### PR DESCRIPTION
This PR contains:

* Prevent input params wrong format, it should be (Persona -> numero_documento), (Persona -> tipo_documento)
* Prevent output wrong format, if the service responses with a wrong format, we shouldn't let it pass the message because we are not able to apply the obligation over the message (just my opinion, we could discuss this).

Note: we assume that the message we received are with a correct XML structure, I mean we shouldn't receive something like this < Persona >< /Personajes >

<img width="1213" alt="screen shot 2017-05-15 at 00 42 09" src="https://cloud.githubusercontent.com/assets/12576190/26041938/7008228c-3907-11e7-9649-2d14c9da20ad.png">

<img width="1191" alt="screen shot 2017-05-15 at 00 42 29" src="https://cloud.githubusercontent.com/assets/12576190/26041947/7962d46c-3907-11e7-9074-bfde75537b24.png">
